### PR TITLE
Add support for V3 Keystore.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainblockchain/ain-util",
-  "version": "1.1.1",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -292,6 +292,27 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -364,6 +385,15 @@
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
+      }
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "drbg.js": {
@@ -581,6 +611,18 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "optional": true
     },
+    "pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -611,6 +653,11 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "scryptsy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
+      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
     },
     "secp256k1": {
       "version": "3.6.2",
@@ -668,6 +715,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
       "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
       "dev": true
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "varuint-bitcoin": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "npm run build-prod && mocha",
+    "test": "npm run build-prod && mocha --timeout 40000",
     "build": "tsc",
     "build-prod": "tsc -p ./tsconfig.prod.json",
     "prepublishOnly": "npm test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainblockchain/ain-util",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "A collection of utility functions for AI Network (AIN). ",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,13 +38,17 @@
   },
   "dependencies": {
     "bn.js": "^4.11.8",
+    "browserify-cipher": "^1.0.1",
     "eccrypto": "^1.1.1",
     "fast-json-stable-stringify": "^2.0.0",
     "keccak": "^2.0.0",
+    "pbkdf2": "^3.0.17",
     "randombytes": "^2.1.0",
     "rlp": "^2.2.2",
     "safe-buffer": "^5.1.2",
+    "scryptsy": "^2.1.0",
     "secp256k1": "^3.6.2",
+    "uuid": "^3.3.3",
     "varuint-bitcoin": "^1.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -647,23 +647,7 @@ export const createAccount = function(entropy?: string): Account {
  * @return {V3Keystore}
  */
 export const privateToV3Keystore = function(
-  privateKey: Buffer,
-  password: string,
-  options: V3KeystoreOptions = {}
-): V3Keystore {
-  const account = privateToAccount(privateKey)
-  return accountToV3Keystore(account, password, options)
-}
-
-/**
- * Converts an account into a V3 Keystore and encrypts it with a password
- * @param {Account} account
- * @param {string} password
- * @param {V3KeystoreOptions} options
- * @return {V3Keystore}
- */
-export const accountToV3Keystore = function(
-    account: Account,
+    privateKey: Buffer,
     password: string,
     options: V3KeystoreOptions = {}
 ): V3Keystore {
@@ -702,15 +686,16 @@ export const accountToV3Keystore = function(
     throw new Error('[ain-util] accountToV3Keystore: Unsupported cipher');
   }
   const ciphertext = Buffer.concat([
-    cipher.update(Buffer.from(account.private_key.replace('0x', ''), 'hex')),
+    cipher.update(Buffer.from(privateKey, 'hex')),
     cipher.final()
   ]);
   const mac = keccak(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))
       .toString('hex').replace('0x', '');
+  const address = privateToAddress(privateKey);
   return {
     version: 3,
     id: uuid.v4({random: options.uuid || randomBytes(16)}),
-    address: account.address.toLowerCase().replace('0x', ''),
+    address: address.toLowerCase().replace('0x', ''),
     crypto: {
       ciphertext: ciphertext.toString('hex'),
       cipherparams: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -679,11 +679,11 @@ export const privateToV3Keystore = function(
         kdfparams.dklen,
       );
   } else {
-    throw new Error('[ain-util] accountToV3Keystore: Unsupported kdf');
+    throw new Error('[ain-util] privateToV3Keystore: Unsupported kdf');
   }
   const cipher = createCipheriv(options.cipher || 'aes-128-ctr', derivedKey.slice(0, 16), iv);
   if (!cipher) {
-    throw new Error('[ain-util] accountToV3Keystore: Unsupported cipher');
+    throw new Error('[ain-util] privateToV3Keystore: Unsupported cipher');
   }
   const ciphertext = Buffer.concat([
     cipher.update(Buffer.from(privateKey, 'hex')),

--- a/src/index.ts
+++ b/src/index.ts
@@ -722,7 +722,7 @@ export const v3KeystoreToPrivate = function(
   let json: V3Keystore = (typeof v3Keystore === 'string') ?
       JSON.parse(v3Keystore.toLowerCase()) : v3Keystore;
   if (json.version !== 3) {
-      throw new Error('[ain-util] fromV3Keystore: Not a valid V3 wallet');
+      throw new Error('[ain-util] v3KeystoreToPrivate: Not a valid V3 wallet');
   }
   let derivedKey: Buffer;
   let kdfparams: KdfParams;
@@ -739,7 +739,7 @@ export const v3KeystoreToPrivate = function(
   } else if (json.crypto.kdf === 'pbkdf2') {
     kdfparams = json.crypto.kdfparams;
     if (kdfparams.prf !== 'hmac-sha256') {
-      throw new Error('[ain-util] fromV3Keystore: Unsupported parameters to PBKDF2');
+      throw new Error('[ain-util] v3KeystoreToPrivate: Unsupported parameters to PBKDF2');
     }
     derivedKey = pbkdf2Sync(
         Buffer.from(password),
@@ -749,13 +749,13 @@ export const v3KeystoreToPrivate = function(
         'sha256'
       );
   } else {
-    throw new Error('[ain-util] fromV3Keystore: Unsupported key derivation scheme');
+    throw new Error('[ain-util] v3KeystoreToPrivate: Unsupported key derivation scheme');
   }
   const ciphertext = Buffer.from(json.crypto.ciphertext, 'hex');
   const mac = keccak(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))
       .toString('hex').replace('0x', '');
   if (mac !== json.crypto.mac) {
-    throw new Error('[ain-util] fromV3Keystore: Key derivation failed - possibly wrong password');
+    throw new Error('[ain-util] v3KeystoreToPrivate: Key derivation failed - possibly wrong password');
   }
   const decipher = createDecipheriv(
       json.crypto.cipher,

--- a/src/index.ts
+++ b/src/index.ts
@@ -667,7 +667,7 @@ export const privateToV3Keystore = function(
         'sha256'
       );
   } else if (kdf === 'scrypt') {
-    kdfparams.n = options.n || 8192; // 2048 4096 8192 16384
+    kdfparams.n = options.n || 262144; // 2048 4096 8192 16384
     kdfparams.r = options.r || 8;
     kdfparams.p = options.p || 1;
     derivedKey = scrypt(

--- a/src/index.ts
+++ b/src/index.ts
@@ -710,14 +710,15 @@ export const privateToV3Keystore = function(
 }
 
 /**
- * Adds an account from a V3 Keystore.
+ * Returns a private key from a V3 Keystore.
  * @param {V3Keystore | string} v3Keystore
- * @param {string} [password]
+ * @param {string} password
+ * @return {Buffer}
  */
-export const fromV3Keystore = function(
+export const v3KeystoreToPrivate = function(
     v3Keystore: V3Keystore | string,
     password: string
-): Account {
+): Buffer {
   let json: V3Keystore = (typeof v3Keystore === 'string') ?
       JSON.parse(v3Keystore.toLowerCase()) : v3Keystore;
   if (json.version !== 3) {
@@ -761,8 +762,7 @@ export const fromV3Keystore = function(
       derivedKey.slice(0, 16),
       Buffer.from(json.crypto.cipherparams.iv, 'hex')
     );
-  const privateKey = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-  return privateToAccount(privateKey);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,11 @@ const secp256k1 = require('secp256k1');
 import { encrypt, decrypt } from 'eccrypto';
 const stringify = require('fast-json-stable-stringify');
 const Buffer = require('safe-buffer').Buffer;
+const scrypt = require('scryptsy');
+const pbkdf2Sync = require('pbkdf2');
 const randomBytes = require('randombytes');
+const { createCipheriv, createDecipheriv } = require('browserify-cipher');
+const uuid = require('uuid');
 const SIGNED_MESSAGE_PREFIX = 'AINetwork Signed Message:\n'
 const SIGNED_MESSAGE_PREFIX_BYTES = Buffer.from(SIGNED_MESSAGE_PREFIX, 'utf8')
 const SIGNED_MESSAGE_PREFIX_LENGTH = encodeVarInt(SIGNED_MESSAGE_PREFIX.length)
@@ -81,6 +85,46 @@ export interface Account {
   address: string;
   private_key: string;
   public_key: string;
+}
+
+export interface KdfParams {
+  dklen: number,
+  salt: string,
+  prf?: string,
+  c?: number,
+  n?: number,
+  r?: number,
+  p?: number
+}
+
+export interface V3KeystoreOptions {
+  salt?: string,
+  iv?: Buffer,
+  kdf?: string,
+  dklen?: number,
+  c?: number,
+  n?: number,
+  r?: number,
+  p?: number,
+  prf?: string,
+  cipher?: string,
+  uuid?: Buffer
+}
+
+export interface V3Keystore {
+  version: 3,
+  id: string,
+  address: string,
+  crypto: {
+    ciphertext: string,
+    cipherparams: {
+      iv: string
+    },
+    cipher: string,
+    kdf: string,
+    kdfparams: KdfParams,
+    mac: string
+  }
 }
 
 /**
@@ -347,6 +391,23 @@ export const pubToAddress = function(
   return keccak(publicKey).slice(-20)
 }
 
+export const privateToAddress = function(privateKey: Buffer): string {
+  return toChecksumAddress(bufferToHex(pubToAddress(privateToPublic(privateKey))))
+}
+
+/**
+ * Returns an Account with the given private key.
+ * @param {Buffer} privateKey
+ * @return {Account}
+ */
+export const privateToAccount = function(privateKey: Buffer): Account {
+  return {
+    address: privateToAddress(privateKey),
+    private_key: privateKey.toString('hex'),
+    public_key: privateToPublic(privateKey).toString('hex')
+  }
+}
+
 // TODO: deprecate this method (serialize)
 /**
  * Serialize an object (e.g. tx data) using rlp encoding.
@@ -575,12 +636,148 @@ export const createAccount = function(entropy?: string): Account {
   const innerHex = keccak(concatHexPrefixed(randomBytes(32), !!entropy ? Buffer.from(entropy) : randomBytes(32)));
   const middleHex = concatHexPrefixed(concatHexPrefixed(randomBytes(32), innerHex), randomBytes(32));
   const privateKey = keccak(middleHex);
-  const publicKey = privateToPublic(privateKey);
+  return privateToAccount(privateKey);
+}
+
+/**
+ * Converts an account into a V3 Keystore and encrypts it with a password
+ * @param {Buffer} privateKey
+ * @param {string} password
+ * @param {V3KeystoreOptions} options
+ * @return {V3Keystore}
+ */
+export const privateToV3Keystore = function(
+  privateKey: Buffer,
+  password: string,
+  options: V3KeystoreOptions = {}
+): V3Keystore {
+  const account = privateToAccount(privateKey)
+  return accountToV3Keystore(account, password, options)
+}
+
+/**
+ * Converts an account into a V3 Keystore and encrypts it with a password
+ * @param {Account} account
+ * @param {string} password
+ * @param {V3KeystoreOptions} options
+ * @return {V3Keystore}
+ */
+export const accountToV3Keystore = function(
+    account: Account,
+    password: string,
+    options: V3KeystoreOptions = {}
+): V3Keystore {
+  const salt = options.salt || randomBytes(32);
+  const iv = options.iv || randomBytes(16);
+  let derivedKey: Buffer;
+  const kdf = options.kdf || 'scrypt';
+  const kdfparams: KdfParams = { dklen: options.dklen || 32, salt: salt.toString('hex') };
+  if (kdf === 'pbkdf2') {
+    kdfparams.c = options.c || 262144;
+    kdfparams.prf = 'hmac-sha256';
+    derivedKey = pbkdf2Sync(
+        Buffer.from(password),
+        Buffer.from(kdfparams.salt, 'hex'),
+        kdfparams.c,
+        kdfparams.dklen,
+        'sha256'
+      );
+  } else if (kdf === 'scrypt') {
+    kdfparams.n = options.n || 8192; // 2048 4096 8192 16384
+    kdfparams.r = options.r || 8;
+    kdfparams.p = options.p || 1;
+    derivedKey = scrypt(
+        Buffer.from(password),
+        Buffer.from(kdfparams.salt, 'hex'),
+        kdfparams.n,
+        kdfparams.r,
+        kdfparams.p,
+        kdfparams.dklen,
+      );
+  } else {
+    throw new Error('[ain-util] accountToV3Keystore: Unsupported kdf');
+  }
+  const cipher = createCipheriv(options.cipher || 'aes-128-ctr', derivedKey.slice(0, 16), iv);
+  if (!cipher) {
+    throw new Error('[ain-util] accountToV3Keystore: Unsupported cipher');
+  }
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(account.private_key.replace('0x', ''), 'hex')),
+    cipher.final()
+  ]);
+  const mac = keccak(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))
+      .toString('hex').replace('0x', '');
   return {
-    address: toChecksumAddress(bufferToHex(pubToAddress(publicKey))),
-    private_key: privateKey.toString('hex'),
-    public_key: publicKey.toString('hex')
+    version: 3,
+    id: uuid.v4({random: options.uuid || randomBytes(16)}),
+    address: account.address.toLowerCase().replace('0x', ''),
+    crypto: {
+      ciphertext: ciphertext.toString('hex'),
+      cipherparams: {
+        iv: iv.toString('hex')
+      },
+      cipher: options.cipher || 'aes-128-ctr',
+      kdf,
+      kdfparams,
+      mac
+    }
   };
+}
+
+/**
+ * Adds an account from a V3 Keystore.
+ * @param {V3Keystore | string} v3Keystore
+ * @param {string} [password]
+ */
+export const fromV3Keystore = function(
+    v3Keystore: V3Keystore | string,
+    password: string
+): Account {
+  let json: V3Keystore = (typeof v3Keystore === 'string') ?
+      JSON.parse(v3Keystore.toLowerCase()) : v3Keystore;
+  if (json.version !== 3) {
+      throw new Error('[ain-util] fromV3Keystore: Not a valid V3 wallet');
+  }
+  let derivedKey: Buffer;
+  let kdfparams: KdfParams;
+  if (json.crypto.kdf === 'scrypt') {
+    kdfparams = json.crypto.kdfparams;
+    derivedKey = scrypt(
+        Buffer.from(password),
+        Buffer.from(kdfparams.salt, 'hex'),
+        kdfparams.n,
+        kdfparams.r,
+        kdfparams.p,
+        kdfparams.dklen
+      );
+  } else if (json.crypto.kdf === 'pbkdf2') {
+    kdfparams = json.crypto.kdfparams;
+    if (kdfparams.prf !== 'hmac-sha256') {
+      throw new Error('[ain-util] fromV3Keystore: Unsupported parameters to PBKDF2');
+    }
+    derivedKey = pbkdf2Sync(
+        Buffer.from(password),
+        Buffer.from(kdfparams.salt, 'hex'),
+        kdfparams.c,
+        kdfparams.dklen,
+        'sha256'
+      );
+  } else {
+    throw new Error('[ain-util] fromV3Keystore: Unsupported key derivation scheme');
+  }
+  const ciphertext = Buffer.from(json.crypto.ciphertext, 'hex');
+  const mac = keccak(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))
+      .toString('hex').replace('0x', '');
+  if (mac !== json.crypto.mac) {
+    throw new Error('[ain-util] fromV3Keystore: Key derivation failed - possibly wrong password');
+  }
+  const decipher = createDecipheriv(
+      json.crypto.cipher,
+      derivedKey.slice(0, 16),
+      Buffer.from(json.crypto.cipherparams.iv, 'hex')
+    );
+  const privateKey = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return privateToAccount(privateKey);
 }
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -196,6 +196,34 @@ describe('privateToPublic', function() {
   })
 })
 
+describe('privateToAddress', function() {
+  it('should get the corresponding checksummed address', function() {
+    assert.equal(utils.privateToAddress(sk), address)
+  })
+})
+
+describe('privateToAccount', function() {
+  it('should get the corresponding account', function() {
+    assert.deepEqual(utils.privateToAccount(sk),
+        {private_key: sk.toString('hex'), public_key: pk.toString('hex'), address})
+  })
+})
+
+describe('V3Keystore', function() {
+  let keystore;
+  const pw = 'password'
+  const account = utils.privateToAccount(sk)
+  it('should create a V3Keystore from the private key', function() {
+    keystore = utils.privateToV3Keystore(sk, pw)
+    assert.deepEqual(utils.fromV3Keystore(keystore, pw), account)
+  })
+
+  it('should create a V3Keystore from the account', function() {
+    keystore = utils.accountToV3Keystore(account, pw)
+    assert.deepEqual(utils.fromV3Keystore(keystore, pw), account)
+  })
+})
+
 describe('toBuffer', function () {
   it('should work', function () {
     // Buffer

--- a/test/index.js
+++ b/test/index.js
@@ -214,7 +214,7 @@ describe('V3Keystore', function() {
     const pw = 'password'
     const account = utils.privateToAccount(sk)
     let keystore = utils.privateToV3Keystore(sk, pw)
-    assert.deepEqual(utils.fromV3Keystore(keystore, pw), account)
+    assert.deepEqual(utils.v3KeystoreToPrivate(keystore, pw), sk)
   })
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -210,11 +210,10 @@ describe('privateToAccount', function() {
 })
 
 describe('V3Keystore', function() {
-  let keystore;
-  const pw = 'password'
-  const account = utils.privateToAccount(sk)
   it('should create a V3Keystore from the private key', function() {
-    keystore = utils.privateToV3Keystore(sk, pw)
+    const pw = 'password'
+    const account = utils.privateToAccount(sk)
+    let keystore = utils.privateToV3Keystore(sk, pw)
     assert.deepEqual(utils.fromV3Keystore(keystore, pw), account)
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -217,11 +217,6 @@ describe('V3Keystore', function() {
     keystore = utils.privateToV3Keystore(sk, pw)
     assert.deepEqual(utils.fromV3Keystore(keystore, pw), account)
   })
-
-  it('should create a V3Keystore from the account', function() {
-    keystore = utils.accountToV3Keystore(account, pw)
-    assert.deepEqual(utils.fromV3Keystore(keystore, pw), account)
-  })
 })
 
 describe('toBuffer', function () {


### PR DESCRIPTION
v3 keystore code reference: https://github.com/ethereum/web3.js/blob/2.x/packages/web3-eth-accounts/src/models/Account.js

- Importing an account from a v3 keystore (fromV3Keystore())
- Exporting an account as a v3 keystore (accountToV3Keystore(), privateToV3Keystore())
- privateToAddress()
- privateToAccount()